### PR TITLE
Switch from byteorder::Error to std::io:Error

### DIFF
--- a/src/blockchain/utils/reader.rs
+++ b/src/blockchain/utils/reader.rs
@@ -406,18 +406,7 @@ tx.lock_time       0x00000000
         // Test error propagation on invalid read
         let inner = Cursor::new([0, 1, 2, 3, 4, 5]);
         let mut reader = BufferedMemoryReader::with_capacity(5, inner);
+        // Reading u64 from 6 bytes, Error has to be std::io::Error(UnexpectedEof)
         assert_eq!(ErrorKind::UnexpectedEof, reader.read_u64::<LittleEndian>().err().unwrap().kind());
-
-        // Reading u64 from 6 bytes, Error has to be ByteOrderError(UnexpectedEOF)
-//        match OpError::from(reader.read_u64::<LittleEndian>().err().unwrap()) {
-//            OpError { kind: OpErrorKind::ByteOrderError(e), .. } => {
-//                // Check error kind
-//                match e {
-//                    std::io::E => { return; }
-//                    _ => panic!()
-//                }
-//            }
-//            _ => panic!()
-//        }
     }
 }

--- a/src/blockchain/utils/reader.rs
+++ b/src/blockchain/utils/reader.rs
@@ -227,10 +227,8 @@ impl<R> fmt::Debug for BufferedMemoryReader<R> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::convert::From;
-    use std::io::{Cursor, Read};
-    use errors::{OpError, OpErrorKind};
-    use byteorder::{self, LittleEndian, ReadBytesExt};
+    use std::io::{Cursor, Read, ErrorKind};
+    use byteorder::{LittleEndian, ReadBytesExt};
     use blockchain::utils::{arr_to_hex_swapped, arr_to_hex};
     use blockchain::proto::script;
     use blockchain::parser::types::{Coin, Bitcoin};
@@ -408,17 +406,18 @@ tx.lock_time       0x00000000
         // Test error propagation on invalid read
         let inner = Cursor::new([0, 1, 2, 3, 4, 5]);
         let mut reader = BufferedMemoryReader::with_capacity(5, inner);
+        assert_eq!(ErrorKind::UnexpectedEof, reader.read_u64::<LittleEndian>().err().unwrap().kind());
 
         // Reading u64 from 6 bytes, Error has to be ByteOrderError(UnexpectedEOF)
-        match OpError::from(reader.read_u64::<LittleEndian>().err().unwrap()) {
-            OpError { kind: OpErrorKind::ByteOrderError(e), .. } => {
-                // Check error kind
-                match e {
-                    byteorder::Error::UnexpectedEOF => { return; }
-                    _ => panic!()
-                }
-            }
-            _ => panic!()
-        }
+//        match OpError::from(reader.read_u64::<LittleEndian>().err().unwrap()) {
+//            OpError { kind: OpErrorKind::ByteOrderError(e), .. } => {
+//                // Check error kind
+//                match e {
+//                    std::io::E => { return; }
+//                    _ => panic!()
+//                }
+//            }
+//            _ => panic!()
+//        }
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -6,7 +6,6 @@ use std::sync;
 use std::string;
 use blockchain::proto::script;
 
-use byteorder;
 use rustc_serialize::json;
 
 
@@ -73,7 +72,7 @@ impl error::Error for OpError {
 pub enum OpErrorKind {
     None,
     IoError(io::Error),
-    ByteOrderError(byteorder::Error),
+    ByteOrderError(io::Error),
     Utf8Error(string::FromUtf8Error),
     ScriptError(script::ScriptError),
     JsonError(String),
@@ -169,12 +168,6 @@ impl<T> convert::From<sync::PoisonError<T>> for OpError {
 impl<T> convert::From<sync::mpsc::SendError<T>> for OpError {
     fn from(_: sync::mpsc::SendError<T>) -> OpError {
         OpError::new(OpErrorKind::SendError)
-    }
-}
-
-impl convert::From<byteorder::Error> for OpError {
-    fn from(err: byteorder::Error) -> OpError {
-        OpError::new(OpErrorKind::ByteOrderError(err))
     }
 }
 


### PR DESCRIPTION
`byteorder` has removed its custom error and suggests switching to `std::io:Error`. 