### PR TITLE
Added short argument "-d" under argument "--blockchain-dir"

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -201,6 +201,7 @@ fn parse_args() -> OpResult<ParserOptions> {
             .possible_values(coins)
             .takes_value(true))
         .arg(Arg::with_name("blockchain-dir")
+            .short("d")
             .long("blockchain-dir")
             .help("Sets blockchain directory which contains blk.dat files (default: ~/.bitcoin/blocks)")
             .takes_value(true))


### PR DESCRIPTION
Added short argument "-d" under argument "--blockchain-dir" to match usage in README.md.