### PR TITLE
Fix to continue parsing while SegWit blocks are found.

### DIFF
--- a/src/blockchain/utils/blkfile.rs
+++ b/src/blockchain/utils/blkfile.rs
@@ -28,7 +28,7 @@ impl BlkFile {
     /// Returns a BufferedMemoryReader to reduce io wait.
     pub fn get_reader(&self) -> OpResult<BufReader<File>> {
         let f = try!(File::open(&self.path));
-        Ok(BufReader::with_capacity(10000000, f))
+        Ok(BufReader::with_capacity(100000000, f))
     }
 
     /// Collects all blk*.dat paths in the given directory


### PR DESCRIPTION
While waiting for proper SegWit support, this fix allows the parser to continue parsing while SegWit blocks are found.