### PR TITLE
Correct resume logic?

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -91,7 +91,7 @@ fn main() {
         };
 
         // Determine ParseMode based on existing chain file
-        let parse_mode = match chain_file.len() == 0 || resume {
+        let parse_mode = match chain_file.len() == 0 || !resume {
             true => ParseMode::Indexing,
             false => ParseMode::FullData
         };


### PR DESCRIPTION
@gcarq: Shouldn't this say !resume? I think this is why, even when resume is included, it's still doing indexing. Maybe I missed some logic though.