### PR TITLE
Update unspentcsvdump

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rusty-blockparser"
 version = "0.7.0"
-authors = ["gcarq <michael.egger@tsn.at>"]
+authors = ["gcarq <egger.m@protonmail.com>"]
 include = ["src/*", "sql/*", "LICENSE", "README.md", "Cargo.toml"]
 description = "Blockchain Parser for most common Cryptocurrencies based on Bitcoin"
 documentation = "https://github.com/gcarq/rusty-blockparser/blob/master/README.md"

--- a/src/callbacks/csvdump.rs
+++ b/src/callbacks/csvdump.rs
@@ -130,7 +130,7 @@ impl Callback for CsvDump {
                                    \t-> transactions: {:9}\n\
                                    \t-> inputs:       {:9}\n\
                                    \t-> outputs:      {:9}",
-             self.end_height + 1, self.tx_count, self.in_count, self.out_count);
+             self.end_height, self.tx_count, self.in_count, self.out_count);
     }
 }
 

--- a/src/callbacks/csvdump.rs
+++ b/src/callbacks/csvdump.rs
@@ -10,7 +10,7 @@ use crate::blockchain::proto::tx::{EvaluatedTxOut, Tx, TxInput};
 use crate::blockchain::proto::Hashed;
 use crate::callbacks::Callback;
 use crate::common::utils;
-use crate::errors::{OpError, OpResult};
+use crate::errors::OpResult;
 
 /// Dumps the whole blockchain into csv files
 pub struct CsvDump {
@@ -30,11 +30,7 @@ pub struct CsvDump {
 
 impl CsvDump {
     fn create_writer(cap: usize, path: PathBuf) -> OpResult<BufWriter<File>> {
-        let file = match File::create(&path) {
-            Ok(f) => f,
-            Err(err) => return Err(OpError::from(err)),
-        };
-        Ok(BufWriter::with_capacity(cap, file))
+        Ok(BufWriter::with_capacity(cap, File::create(&path)?))
     }
 }
 
@@ -46,7 +42,7 @@ impl Callback for CsvDump {
         SubCommand::with_name("csvdump")
             .about("Dumps the whole blockchain into CSV files")
             .version("0.1")
-            .author("gcarq <michael.egger@tsn.at>")
+            .author("gcarq <egger.m@protonmail.com>")
             .arg(
                 Arg::with_name("dump-folder")
                     .help("Folder to store csv files")

--- a/src/callbacks/csvdump.rs
+++ b/src/callbacks/csvdump.rs
@@ -14,7 +14,7 @@ use crate::errors::OpResult;
 
 /// Dumps the whole blockchain into csv files
 pub struct CsvDump {
-    // Each structure gets stored in a seperate csv file
+    // Each structure gets stored in a separate csv file
     dump_folder: PathBuf,
     block_writer: BufWriter<File>,
     tx_writer: BufWriter<File>,
@@ -56,29 +56,20 @@ impl Callback for CsvDump {
         Self: Sized,
     {
         let dump_folder = &PathBuf::from(matches.value_of("dump-folder").unwrap()); // Save to unwrap
-        match (|| -> OpResult<Self> {
-            let cap = 4000000;
-            let cb = CsvDump {
-                dump_folder: PathBuf::from(dump_folder),
-                block_writer: CsvDump::create_writer(cap, dump_folder.join("blocks.csv.tmp"))?,
-                tx_writer: CsvDump::create_writer(cap, dump_folder.join("transactions.csv.tmp"))?,
-                txin_writer: CsvDump::create_writer(cap, dump_folder.join("tx_in.csv.tmp"))?,
-                txout_writer: CsvDump::create_writer(cap, dump_folder.join("tx_out.csv.tmp"))?,
-                start_height: 0,
-                end_height: 0,
-                tx_count: 0,
-                in_count: 0,
-                out_count: 0,
-            };
-            Ok(cb)
-        })() {
-            Ok(s) => Ok(s),
-            Err(e) => Err(tag_err!(
-                e,
-                "Couldn't initialize csvdump with folder: `{}`",
-                dump_folder.as_path().display()
-            )),
-        }
+        let cap = 4000000;
+        let cb = CsvDump {
+            dump_folder: PathBuf::from(dump_folder),
+            block_writer: CsvDump::create_writer(cap, dump_folder.join("blocks.csv.tmp"))?,
+            tx_writer: CsvDump::create_writer(cap, dump_folder.join("transactions.csv.tmp"))?,
+            txin_writer: CsvDump::create_writer(cap, dump_folder.join("tx_in.csv.tmp"))?,
+            txout_writer: CsvDump::create_writer(cap, dump_folder.join("tx_out.csv.tmp"))?,
+            start_height: 0,
+            end_height: 0,
+            tx_count: 0,
+            in_count: 0,
+            out_count: 0,
+        };
+        Ok(cb)
     }
 
     fn on_start(&mut self, _: &CoinType, block_height: u64) {

--- a/src/callbacks/stats.rs
+++ b/src/callbacks/stats.rs
@@ -181,7 +181,7 @@ impl Callback for SimpleStats {
     where
         Self: Sized,
     {
-        Ok(Default::default())
+        Ok(SimpleStats::default())
     }
 
     fn on_start(&mut self, _: &CoinType, _: u64) {

--- a/src/callbacks/stats.rs
+++ b/src/callbacks/stats.rs
@@ -1,6 +1,7 @@
-use clap::{App, ArgMatches, SubCommand};
 use std::collections::HashMap;
 use std::io::{self, Write};
+
+use clap::{App, ArgMatches, SubCommand};
 
 use crate::blockchain::parser::types::CoinType;
 use crate::blockchain::proto::block::{self, Block};
@@ -173,7 +174,7 @@ impl Callback for SimpleStats {
         SubCommand::with_name("simplestats")
             .about("Shows various Blockchain stats")
             .version("0.1")
-            .author("gcarq <michael.egger@tsn.at>")
+            .author("gcarq <egger.m@protonmail.com>")
     }
 
     fn new(_: &ArgMatches) -> OpResult<Self>

--- a/src/callbacks/unspentcsvdump.rs
+++ b/src/callbacks/unspentcsvdump.rs
@@ -62,30 +62,21 @@ impl Callback for UnspentCsvDump {
         Self: Sized,
     {
         let dump_folder = &PathBuf::from(matches.value_of("dump-folder").unwrap()); // Save to unwrap
-        match (|| -> OpResult<Self> {
-            let cap = 4000000;
-            let cb = UnspentCsvDump {
-                dump_folder: PathBuf::from(dump_folder),
-                unspent_writer: UnspentCsvDump::create_writer(
-                    cap,
-                    dump_folder.join("unspent.csv.tmp"),
-                )?,
-                unspents: HashMap::with_capacity(10000000), // Init hashmap for tracking the unspent transactions (with 10'000'000 mln preallocated entries)
-                start_height: 0,
-                end_height: 0,
-                tx_count: 0,
-                in_count: 0,
-                out_count: 0,
-            };
-            Ok(cb)
-        })() {
-            Ok(s) => Ok(s),
-            Err(e) => Err(tag_err!(
-                e,
-                "Couldn't initialize csvdump with folder: `{}`",
-                dump_folder.as_path().display()
-            )),
-        }
+        let cb = UnspentCsvDump {
+            dump_folder: PathBuf::from(dump_folder),
+            unspent_writer: UnspentCsvDump::create_writer(
+                4000000,
+                dump_folder.join("unspent.csv.tmp"),
+            )?,
+            // Init hashmap for tracking the unspent transactions (with 10'000'000 mln preallocated entries)
+            unspents: HashMap::with_capacity(10000000),
+            start_height: 0,
+            end_height: 0,
+            tx_count: 0,
+            in_count: 0,
+            out_count: 0,
+        };
+        Ok(cb)
     }
 
     fn on_start(&mut self, _: &CoinType, block_height: u64) {

--- a/src/callbacks/unspentcsvdump.rs
+++ b/src/callbacks/unspentcsvdump.rs
@@ -1,24 +1,25 @@
-use std::collections::hash_map::Entry::{Occupied, Vacant};
 use std::collections::HashMap;
 use std::fs::{self, File};
 use std::io::{BufWriter, Write};
 use std::path::PathBuf;
 
+use byteorder::{LittleEndian, ReadBytesExt};
 use clap::{App, Arg, ArgMatches, SubCommand};
 
 use crate::blockchain::parser::types::CoinType;
 use crate::blockchain::proto::block::Block;
+use crate::blockchain::proto::tx::TxOutpoint;
 use crate::callbacks::Callback;
 use crate::common::utils;
-use crate::errors::{OpError, OpResult};
+use crate::errors::OpResult;
 
-/// Dumps the whole blockchain into csv files
+/// Dumps the UTXOs along with address in a csv file
 pub struct UnspentCsvDump {
-    // Each structure gets stored in a separate csv file
     dump_folder: PathBuf,
     unspent_writer: BufWriter<File>,
 
-    transactions_unspent: HashMap<String, HashMapVal>,
+    // key: txid + index
+    unspents: HashMap<Vec<u8>, HashMapVal>,
 
     start_height: u64,
     end_height: u64,
@@ -28,8 +29,6 @@ pub struct UnspentCsvDump {
 }
 
 struct HashMapVal {
-    /*	txid:	String,
-    index:	usize,*/
     block_height: u64,
     output_val: u64,
     address: String,
@@ -37,11 +36,7 @@ struct HashMapVal {
 
 impl UnspentCsvDump {
     fn create_writer(cap: usize, path: PathBuf) -> OpResult<BufWriter<File>> {
-        let file = match File::create(&path) {
-            Ok(f) => f,
-            Err(err) => return Err(OpError::from(err)),
-        };
-        Ok(BufWriter::with_capacity(cap, file))
+        Ok(BufWriter::with_capacity(cap, File::create(&path)?))
     }
 }
 
@@ -75,7 +70,7 @@ impl Callback for UnspentCsvDump {
                     cap,
                     dump_folder.join("unspent.csv.tmp"),
                 )?,
-                transactions_unspent: HashMap::with_capacity(10000000), // Init hashmap for tracking the unspent transactions (with 10'000'000 mln preallocated entries)
+                unspents: HashMap::with_capacity(10000000), // Init hashmap for tracking the unspent transactions (with 10'000'000 mln preallocated entries)
                 start_height: 0,
                 end_height: 0,
                 tx_count: 0,
@@ -99,7 +94,6 @@ impl Callback for UnspentCsvDump {
     }
 
     fn on_block(&mut self, block: &Block, block_height: u64) {
-        // serialize transaction
         for tx in &block.txs {
             // For each transaction in the block,
             // 1. apply input transactions (remove (TxID == prevTxIDOut and prevOutID == spentOutID))
@@ -108,37 +102,23 @@ impl Callback for UnspentCsvDump {
             // * block height as "last modified"
             // * output_val
             // * address
-
-            //self.tx_writer.write_all(tx.as_csv(&block_hash).as_bytes()).unwrap();
-            let txid_str = utils::arr_to_hex_swapped(&tx.hash);
-
             for input in &tx.value.inputs {
-                let input_outpoint_txid_idx = utils::arr_to_hex_swapped(&input.outpoint.txid)
-                    + &input.outpoint.index.to_string();
-                let val: bool = match self
-                    .transactions_unspent
-                    .entry(input_outpoint_txid_idx.clone())
-                {
-                    Occupied(_) => true,
-                    Vacant(_) => false,
-                };
-
-                if val {
-                    self.transactions_unspent.remove(&input_outpoint_txid_idx);
-                };
+                let TxOutpoint { txid, index } = input.outpoint;
+                let key = [&txid[..], &index.to_le_bytes()[..]].concat();
+                if self.unspents.contains_key(&key) {
+                    self.unspents.remove(&key);
+                }
             }
             self.in_count += tx.value.in_count.value;
-
-            // serialize outputs
             for (i, output) in tx.value.outputs.iter().enumerate() {
+                let index = i as u32;
                 let hash_val: HashMapVal = HashMapVal {
                     block_height,
                     output_val: output.out.value,
                     address: output.script.address.clone(),
-                    //script_pubkey: utils::arr_to_hex(&output.out.script_pubkey)
                 };
-                self.transactions_unspent
-                    .insert(txid_str.clone() + &i.to_string(), hash_val);
+                let key = [&tx.hash[..], &index.to_le_bytes()[..]].concat();
+                self.unspents.insert(key, hash_val);
             }
             self.out_count += tx.value.out_count.value;
         }
@@ -157,17 +137,18 @@ impl Callback for UnspentCsvDump {
                 .as_bytes(),
             )
             .unwrap();
-        for (key, value) in self.transactions_unspent.iter() {
-            let txid = &key[0..64];
-            let index = &key[64..];
-            //let  = key.len();
-            //let mut mut_key = key.clone();
-            //let index: String = mut_key.pop().unwrap().to_string();
+        for (key, value) in self.unspents.iter() {
+            let txid = &key[0..32];
+            let mut index = &key[32..];
             self.unspent_writer
                 .write_all(
                     format!(
                         "{};{};{};{};{}\n",
-                        txid, index, value.block_height, value.output_val, value.address
+                        utils::arr_to_hex_swapped(txid),
+                        index.read_u32::<LittleEndian>().unwrap(),
+                        value.block_height,
+                        value.output_val,
+                        value.address
                     )
                     .as_bytes(),
                 )
@@ -176,7 +157,7 @@ impl Callback for UnspentCsvDump {
 
         // Keep in sync with c'tor
         for f in &["unspent"] {
-            // Rename temp files
+            // Rename temp file
             fs::rename(
                 self.dump_folder.as_path().join(format!("{}.csv.tmp", f)),
                 self.dump_folder.as_path().join(format!(

--- a/src/callbacks/unspentcsvdump.rs
+++ b/src/callbacks/unspentcsvdump.rs
@@ -84,15 +84,15 @@ impl Callback for UnspentCsvDump {
         info!(target: "callback", "Using `unspentcsvdump` with dump folder: {} ...", &self.dump_folder.display());
     }
 
+    /// For each transaction in the block
+    ///   1. apply input transactions (remove (TxID == prevTxIDOut and prevOutID == spentOutID))
+    ///   2. apply output transactions (add (TxID + curOutID -> HashMapVal))
+    /// For each address, retain:
+    ///   * block height as "last modified"
+    ///   * output_val
+    ///   * address
     fn on_block(&mut self, block: &Block, block_height: u64) {
         for tx in &block.txs {
-            // For each transaction in the block,
-            // 1. apply input transactions (remove (TxID == prevTxIDOut and prevOutID == spentOutID))
-            // 2. apply output transactions (add (TxID + curOutID -> HashMapVal))
-            // For each address, retain:
-            // * block height as "last modified"
-            // * output_val
-            // * address
             for input in &tx.value.inputs {
                 let TxOutpoint { txid, index } = input.outpoint;
                 let key = [&txid[..], &index.to_le_bytes()[..]].concat();
@@ -163,6 +163,6 @@ impl Callback for UnspentCsvDump {
                                    \t-> transactions: {:9}\n\
                                    \t-> inputs:       {:9}\n\
                                    \t-> outputs:      {:9}",
-             self.end_height + 1, self.tx_count, self.in_count, self.out_count);
+             self.end_height, self.tx_count, self.in_count, self.out_count);
     }
 }

--- a/src/callbacks/unspentcsvdump.rs
+++ b/src/callbacks/unspentcsvdump.rs
@@ -12,7 +12,6 @@ use crate::blockchain::proto::tx::TxOutpoint;
 use crate::callbacks::Callback;
 use crate::common::utils;
 use crate::errors::OpResult;
-
 /// Dumps the UTXOs along with address in a csv file
 pub struct UnspentCsvDump {
     dump_folder: PathBuf,
@@ -29,7 +28,6 @@ pub struct UnspentCsvDump {
 }
 
 struct HashMapVal {
-    block_height: u64,
     output_val: u64,
     address: String,
 }
@@ -91,7 +89,7 @@ impl Callback for UnspentCsvDump {
     ///   * block height as "last modified"
     ///   * output_val
     ///   * address
-    fn on_block(&mut self, block: &Block, block_height: u64) {
+    fn on_block(&mut self, block: &Block, _: u64) {
         for tx in &block.txs {
             for input in &tx.value.inputs {
                 let TxOutpoint { txid, index } = input.outpoint;
@@ -104,7 +102,6 @@ impl Callback for UnspentCsvDump {
             for (i, output) in tx.value.outputs.iter().enumerate() {
                 let index = i as u32;
                 let hash_val: HashMapVal = HashMapVal {
-                    block_height,
                     output_val: output.out.value,
                     address: output.script.address.clone(),
                 };
@@ -120,13 +117,7 @@ impl Callback for UnspentCsvDump {
         self.end_height = block_height;
 
         self.unspent_writer
-            .write_all(
-                format!(
-                    "{};{};{};{};{}\n",
-                    "txid", "indexOut", "height", "value", "address"
-                )
-                .as_bytes(),
-            )
+            .write_all(format!("{};{};{};{}\n", "txid", "indexOut", "value", "address").as_bytes())
             .unwrap();
         for (key, value) in self.unspents.iter() {
             let txid = &key[0..32];
@@ -134,10 +125,9 @@ impl Callback for UnspentCsvDump {
             self.unspent_writer
                 .write_all(
                     format!(
-                        "{};{};{};{};{}\n",
+                        "{};{};{};{}\n",
                         utils::arr_to_hex_swapped(txid),
                         index.read_u32::<LittleEndian>().unwrap(),
-                        value.block_height,
                         value.output_val,
                         value.address
                     )

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -24,13 +24,6 @@ macro_rules! transform {
     }};
 }
 
-/// Tags a OpError with a additional description
-macro_rules! tag_err {
-    ($e:expr, $($arg:tt)*) => (
-        $e.join_msg(&format!( $($arg)* ))
-    );
-}
-
 pub type OpResult<T> = Result<T, OpError>;
 
 #[derive(Debug)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -122,7 +122,7 @@ fn parse_args() -> OpResult<RefCell<ParserOptions>> {
     ];
     let matches = App::new("Multithreaded Blockchain Parser written in Rust")
         .version(crate_version!())
-        .author("gcarq <michael.egger@tsn.at>")
+        .author("gcarq <egger.m@protonmail.com>")
         // Add flags
         .arg(Arg::with_name("verify")
             .long("verify")


### PR DESCRIPTION
* remove unneeded `Vec<u8> -> String` conversions of txids
* remove block height in serialized data to improve memory footprint
* improve hashmap lookup performance