### PR TITLE
Parallel transaction evaluation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,6 +122,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "maybe-uninit",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "lazy_static",
+ "maybe-uninit",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "774ba60a54c213d409d5353bda12d49cd68d14e45036a285234c8d6f91f92570"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "maybe-uninit",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -157,6 +194,12 @@ name = "discard"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
+
+[[package]]
+name = "either"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 
 [[package]]
 name = "errno"
@@ -255,6 +298,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "maybe-uninit"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
+
+[[package]]
+name = "memoffset"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c198b026e1bbf08a937e94c6c60f9ec4a2267f5b0d2eec9c1b21b061ce2be55f"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "num"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -328,6 +386,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -440,6 +508,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62f02856753d04e03e26929f820d0a0a337ebe71f849801eea335d464b349080"
+dependencies = [
+ "autocfg",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e92e15d89083484e11353891f1af602cc661426deb9564c298b270c726973280"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-queue",
+ "crossbeam-utils",
+ "lazy_static",
+ "num_cpus",
+]
+
+[[package]]
 name = "rdrand"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -522,6 +615,7 @@ dependencies = [
  "clap",
  "dirs",
  "log",
+ "rayon",
  "rust-base58",
  "rust-crypto",
  "rusty-leveldb",
@@ -547,6 +641,12 @@ name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "semver"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ byteorder = "^1.3"
 rust-base58 = "^0.0"
 rusty-leveldb = "^0.3"
 dirs = "^3.0"
+rayon = "^1.3"
 
 # The development profile, used for `cargo build`
 [profile.dev]

--- a/src/blockchain/proto/mod.rs
+++ b/src/blockchain/proto/mod.rs
@@ -15,7 +15,6 @@ pub trait ToRaw {
 }
 
 /// Wrapper to hold a 32 byte verification hash along the data type T
-#[derive(Clone)]
 pub struct Hashed<T> {
     pub hash: [u8; 32],
     pub value: T,

--- a/src/blockchain/proto/script.rs
+++ b/src/blockchain/proto/script.rs
@@ -153,7 +153,6 @@ impl fmt::Debug for Stack {
     }
 }
 
-#[derive(Clone)]
 pub struct EvaluatedScript {
     pub address: Option<String>,
     pub pattern: ScriptPattern,

--- a/src/blockchain/proto/tx.rs
+++ b/src/blockchain/proto/tx.rs
@@ -110,7 +110,7 @@ impl ToRaw for EvaluatedTx {
 }
 
 /// TxOutpoint references an existing transaction output
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(PartialEq, Eq, Hash)]
 pub struct TxOutpoint {
     pub txid: [u8; 32],
     pub index: u32, // 0-based offset within tx
@@ -142,7 +142,6 @@ impl fmt::Debug for TxOutpoint {
 }
 
 /// Holds TxInput informations
-#[derive(Clone)]
 pub struct TxInput {
     pub outpoint: TxOutpoint,
     pub script_len: VarUint,
@@ -174,7 +173,6 @@ impl fmt::Debug for TxInput {
 }
 
 /// Evaluates script_pubkey and wraps TxOutput
-#[derive(Clone)]
 pub struct EvaluatedTxOut {
     pub script: script::EvaluatedScript,
     pub out: TxOutput,
@@ -191,7 +189,6 @@ impl EvaluatedTxOut {
 }
 
 /// Holds TxOutput informations
-#[derive(Clone)]
 pub struct TxOutput {
     pub value: u64,
     pub script_len: VarUint,

--- a/src/callbacks/common.rs
+++ b/src/callbacks/common.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::blockchain::proto::tx::Tx;
+use crate::blockchain::proto::tx::EvaluatedTx;
 use crate::blockchain::proto::tx::TxOutpoint;
 use crate::blockchain::proto::Hashed;
 use crate::blockchain::proto::ToRaw;
@@ -14,7 +14,10 @@ pub struct UnspentValue {
 
 /// Iterates over transaction inputs and removes spent outputs from HashMap.
 /// Returns the total number of processed inputs.
-pub fn remove_unspents(tx: &Hashed<Tx>, unspents: &mut HashMap<Vec<u8>, UnspentValue>) -> u64 {
+pub fn remove_unspents(
+    tx: &Hashed<EvaluatedTx>,
+    unspents: &mut HashMap<Vec<u8>, UnspentValue>,
+) -> u64 {
     for input in &tx.value.inputs {
         let key = input.outpoint.to_bytes();
         if unspents.contains_key(&key) {
@@ -27,7 +30,7 @@ pub fn remove_unspents(tx: &Hashed<Tx>, unspents: &mut HashMap<Vec<u8>, UnspentV
 /// Iterates over transaction outputs and adds valid unspents to HashMap.
 /// Returns the total number of valid outputs.
 pub fn insert_unspents(
-    tx: &Hashed<Tx>,
+    tx: &Hashed<EvaluatedTx>,
     block_height: u64,
     unspents: &mut HashMap<Vec<u8>, UnspentValue>,
 ) -> u64 {
@@ -103,7 +106,7 @@ mod tests {
         ];
         let mut reader = BufReader::new(Cursor::new(raw_data));
         let txs = reader.read_txs(1, 0x00).unwrap();
-        let block1 = Block::new(0, header.clone(), VarUint::from(1u8), txs.clone());
+        let block1 = Block::new(0, header.clone(), VarUint::from(1u8), txs);
 
         for tx in &block1.txs {
             remove_unspents(&tx, &mut unspents);
@@ -241,7 +244,7 @@ mod tests {
         ];
         let mut reader = BufReader::new(Cursor::new(raw_data));
         let txs = reader.read_txs(1, 0x00).unwrap();
-        let block2 = Block::new(0, header.clone(), VarUint::from(1u8), txs.clone());
+        let block2 = Block::new(0, header.clone(), VarUint::from(1u8), txs);
 
         for tx in &block2.txs {
             remove_unspents(&tx, &mut unspents);

--- a/src/callbacks/csvdump.rs
+++ b/src/callbacks/csvdump.rs
@@ -6,7 +6,7 @@ use clap::{App, Arg, ArgMatches, SubCommand};
 
 use crate::blockchain::parser::types::CoinType;
 use crate::blockchain::proto::block::Block;
-use crate::blockchain::proto::tx::{EvaluatedTxOut, Tx, TxInput};
+use crate::blockchain::proto::tx::{EvaluatedTx, EvaluatedTxOut, TxInput};
 use crate::blockchain::proto::Hashed;
 use crate::callbacks::Callback;
 use crate::common::utils;
@@ -151,7 +151,7 @@ impl Block {
     }
 }
 
-impl Hashed<Tx> {
+impl Hashed<EvaluatedTx> {
     #[inline]
     fn as_csv(&self, block_hash: &str) -> String {
         // (@txid, @hashBlock, version, lockTime)

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ extern crate time;
 #[macro_use]
 extern crate clap;
 extern crate byteorder;
+extern crate rayon;
 extern crate rust_base58;
 extern crate rusty_leveldb;
 


### PR DESCRIPTION
Use rayon to parallel transaction evaluation.
This speeds up parsing speed for blocks with a lot of transactions.

TODO: 
* Check memory usage for different callbacks
* Create feature flag is memory usage is too high