### PR TITLE
bump clap dependency to 4.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,23 +3,52 @@
 version = 3
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
+name = "anstream"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
 dependencies = [
- "winapi",
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is-terminal",
+ "utf8parse",
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
+name = "anstyle"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
 dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -104,18 +133,38 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "4.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "d9394150f5b4273a1763355bd1c2ec54cc5a2593f790587bcd6b2c947cfa9211"
 dependencies = [
- "ansi_term",
- "atty",
- "bitflags",
- "strsim",
- "textwrap",
- "unicode-width",
- "vec_map",
+ "clap_builder",
 ]
+
+[[package]]
+name = "clap_builder"
+version = "4.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a78fbdd3cc2914ddf37ba444114bc7765bbdcb55ec9cbe6fa054f0137400717"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "bitflags",
+ "clap_lex",
+ "once_cell",
+ "strsim",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "crc"
@@ -186,7 +235,7 @@ checksum = "04414300db88f70d74c5ff54e50f9e1d1737d9a5b90f53fcf2e95ca2a9ab554b"
 dependencies = [
  "libc",
  "redox_users",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -207,6 +256,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "errno-dragonfly"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -214,6 +274,15 @@ checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
 ]
 
 [[package]]
@@ -250,15 +319,6 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
@@ -267,10 +327,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
 name = "hex_lit"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "integer-encoding"
@@ -279,10 +354,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
+name = "io-lifetimes"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "log"
@@ -330,6 +434,12 @@ dependencies = [
  "hermit-abi 0.2.6",
  "libc",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "ppv-lite86"
@@ -428,14 +538,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
  "getrandom 0.2.9",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "thiserror",
+]
+
+[[package]]
+name = "rustix"
+version = "0.37.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
+dependencies = [
+ "bitflags",
+ "errno 0.3.1",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -451,6 +584,7 @@ dependencies = [
  "rayon",
  "rusty-leveldb",
  "seek_bufread",
+ "tempfile",
 ]
 
 [[package]]
@@ -460,7 +594,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04c67700d4731d7c35c914a844dba95ae6689a419a576433c745b76757a555db"
 dependencies = [
  "crc",
- "errno",
+ "errno 0.2.8",
  "fs2",
  "integer-encoding",
  "rand",
@@ -506,9 +640,9 @@ checksum = "5e9f0ab6ef7eb7353d9119c170a436d1bf248eea575ac42d19d12f4e34130831"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
@@ -522,12 +656,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.11.0"
+name = "tempfile"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
 dependencies = [
- "unicode-width",
+ "autocfg",
+ "cfg-if",
+ "fastrand",
+ "redox_syscall 0.3.5",
+ "rustix",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -557,16 +696,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
 
 [[package]]
-name = "unicode-width"
-version = "0.1.10"
+name = "utf8parse"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "wasi"
@@ -608,7 +741,16 @@ version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -617,13 +759,28 @@ version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
 ]
 
 [[package]]
@@ -633,10 +790,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -645,10 +814,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -657,13 +838,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,16 @@ edition = "2021"
 [dependencies]
 log = { version = "^0.4", default-features = false, features = ["std"] }
 chrono = { version = "^0.4.24", default-features = false, features = ["std"] }
-clap = "^2.34.0"
+clap = { version = "^4.3.8", features = [ "cargo" ] }
 byteorder = "^1.3"
 rusty-leveldb = "^1.0.6"
 dirs = "^5.0.0"
 bitcoin = "^0.30.0"
 rayon = "^1.3"
 seek_bufread = "^1.2.2"
+
+[dev-dependencies]
+tempfile =  "^3.6.0"
 
 # The development profile, used for `cargo build`
 [profile.dev]

--- a/README.md
+++ b/README.md
@@ -17,31 +17,33 @@ If something doesn't match the parser exits.
 
 ## Usage
 ```
-USAGE:
-    rusty-blockparser [FLAGS] [OPTIONS] [SUBCOMMAND]
+Usage: rusty-blockparser [OPTIONS] [COMMAND]
 
-FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
-    -v               Increases verbosity level. Info=0, Debug=1, Trace=2 (default: 0)
-        --verify     Verifies the leveldb index integrity and verifies merkle roots
+Commands:
+  unspentcsvdump  Dumps the unspent outputs to CSV file
+  csvdump         Dumps the whole blockchain into CSV files
+  simplestats     Shows various Blockchain stats
+  balances        Dumps all addresses with non-zero balance to CSV file
+  opreturn        Shows embedded OP_RETURN data that is representable as UTF8
+  help            Print this message or the help of the given subcommand(s)
 
-OPTIONS:
-    -d, --blockchain-dir <blockchain-dir>    Sets blockchain directory which contains blk.dat files (default:
-                                             ~/.bitcoin/blocks)
-    -c, --coin <NAME>                        Specify blockchain coin (default: bitcoin) [possible values: bitcoin,
-                                             testnet3, namecoin, litecoin, dogecoin, myriadcoin, unobtanium,
-                                             noteblockchain]
-    -e, --end <HEIGHT>                       Specify last block for parsing (inclusive) (default: all known blocks)
-    -s, --start <HEIGHT>                     Specify starting block for parsing (inclusive)
-
-SUBCOMMANDS:
-    balances          Dumps all addresses with non-zero balance to CSV file
-    csvdump           Dumps the whole blockchain into CSV files
-    help              Prints this message or the help of the given subcommand(s)
-    opreturn          Shows embedded OP_RETURN data that is representable as UTF8
-    simplestats       Shows various Blockchain stats
-    unspentcsvdump    Dumps the unspent outputs to CSV file
+Options:
+      --verify
+          Verifies merkle roots and block hashes
+  -v...
+          Increases verbosity level. Info=0, Debug=1, Trace=2 (default: 0)
+  -c, --coin <NAME>
+          Specify blockchain coin (default: bitcoin) [possible values: bitcoin, testnet3, namecoin, litecoin, dogecoin, myriadcoin, unobtanium, noteblockchain]
+  -d, --blockchain-dir <blockchain-dir>
+          Sets blockchain directory which contains blk.dat files (default: ~/.bitcoin/blocks)
+  -s, --start <HEIGHT>
+          Specify starting block for parsing (inclusive)
+  -e, --end <HEIGHT>
+          Specify last block for parsing (inclusive) (default: all known blocks)
+  -h, --help
+          Print help
+  -V, --version
+          Print version
 ```
 ### Example
 

--- a/src/callbacks/balances.rs
+++ b/src/callbacks/balances.rs
@@ -3,7 +3,7 @@ use std::fs::{self, File};
 use std::io::{BufWriter, Write};
 use std::path::PathBuf;
 
-use clap::{App, Arg, ArgMatches, SubCommand};
+use clap::{Arg, ArgMatches, Command};
 
 use crate::blockchain::proto::block::Block;
 use crate::callbacks::{common, Callback};
@@ -28,16 +28,16 @@ impl Balances {
 }
 
 impl Callback for Balances {
-    fn build_subcommand<'a, 'b>() -> App<'a, 'b>
+    fn build_subcommand() -> Command
     where
         Self: Sized,
     {
-        SubCommand::with_name("balances")
+        Command::new("balances")
             .about("Dumps all addresses with non-zero balance to CSV file")
             .version("0.1")
             .author("gcarq <egger.m@protonmail.com>")
             .arg(
-                Arg::with_name("dump-folder")
+                Arg::new("dump-folder")
                     .help("Folder to store csv file")
                     .index(1)
                     .required(true),
@@ -48,7 +48,7 @@ impl Callback for Balances {
     where
         Self: Sized,
     {
-        let dump_folder = &PathBuf::from(matches.value_of("dump-folder").unwrap());
+        let dump_folder = &PathBuf::from(matches.get_one::<String>("dump-folder").unwrap());
         let cb = Balances {
             dump_folder: PathBuf::from(dump_folder),
             writer: Balances::create_writer(4000000, dump_folder.join("balances.csv.tmp"))?,

--- a/src/callbacks/csvdump.rs
+++ b/src/callbacks/csvdump.rs
@@ -2,7 +2,7 @@ use std::fs::{self, File};
 use std::io::{BufWriter, Write};
 use std::path::PathBuf;
 
-use clap::{App, Arg, ArgMatches, SubCommand};
+use clap::{Arg, ArgMatches, Command};
 
 use crate::blockchain::proto::block::Block;
 use crate::blockchain::proto::tx::{EvaluatedTx, EvaluatedTxOut, TxInput};
@@ -33,16 +33,16 @@ impl CsvDump {
 }
 
 impl Callback for CsvDump {
-    fn build_subcommand<'a, 'b>() -> App<'a, 'b>
+    fn build_subcommand() -> Command
     where
         Self: Sized,
     {
-        SubCommand::with_name("csvdump")
+        Command::new("csvdump")
             .about("Dumps the whole blockchain into CSV files")
             .version("0.1")
             .author("gcarq <egger.m@protonmail.com>")
             .arg(
-                Arg::with_name("dump-folder")
+                Arg::new("dump-folder")
                     .help("Folder to store csv files")
                     .index(1)
                     .required(true),
@@ -53,7 +53,7 @@ impl Callback for CsvDump {
     where
         Self: Sized,
     {
-        let dump_folder = &PathBuf::from(matches.value_of("dump-folder").unwrap());
+        let dump_folder = &PathBuf::from(matches.get_one::<String>("dump-folder").unwrap());
         let cap = 4000000;
         let cb = CsvDump {
             dump_folder: PathBuf::from(dump_folder),

--- a/src/callbacks/mod.rs
+++ b/src/callbacks/mod.rs
@@ -1,4 +1,4 @@
-use clap::{App, ArgMatches};
+use clap::{ArgMatches, Command};
 
 use crate::blockchain::proto::block::Block;
 use crate::errors::OpResult;
@@ -14,9 +14,9 @@ pub mod unspentcsvdump;
 /// The parser ensures that the blocks arrive in the correct order.
 /// At this stage the main chain is already determined and orphans/stales are removed.
 pub trait Callback {
-    /// Builds SubCommand to specify callback name and required args,
+    /// Builds Command to specify callback name and required args,
     /// exits if some required args are missing.
-    fn build_subcommand<'a, 'b>() -> App<'a, 'b>
+    fn build_subcommand() -> Command
     where
         Self: Sized;
 

--- a/src/callbacks/opreturn.rs
+++ b/src/callbacks/opreturn.rs
@@ -1,4 +1,4 @@
-use clap::{App, ArgMatches, SubCommand};
+use clap::{ArgMatches, Command};
 
 use crate::blockchain::proto::block::Block;
 use crate::blockchain::proto::script::ScriptPattern;
@@ -9,11 +9,11 @@ use crate::errors::OpResult;
 pub struct OpReturn;
 
 impl Callback for OpReturn {
-    fn build_subcommand<'a, 'b>() -> App<'a, 'b>
+    fn build_subcommand() -> Command
     where
         Self: Sized,
     {
-        SubCommand::with_name("opreturn")
+        Command::new("opreturn")
             .about("Shows embedded OP_RETURN data that is representable as UTF8")
             .version("0.1")
             .author("gcarq <egger.m@protonmail.com>")

--- a/src/callbacks/simplestats.rs
+++ b/src/callbacks/simplestats.rs
@@ -2,7 +2,7 @@ use bitcoin::hashes::{sha256d, Hash};
 use std::collections::HashMap;
 use std::io::{self, Write};
 
-use clap::{App, ArgMatches, SubCommand};
+use clap::{ArgMatches, Command};
 
 use crate::blockchain::proto::block::{self, Block};
 use crate::blockchain::proto::script::ScriptPattern;
@@ -182,11 +182,11 @@ impl SimpleStats {
 }
 
 impl Callback for SimpleStats {
-    fn build_subcommand<'a, 'b>() -> App<'a, 'b>
+    fn build_subcommand() -> Command
     where
         Self: Sized,
     {
-        SubCommand::with_name("simplestats")
+        Command::new("simplestats")
             .about("Shows various Blockchain stats")
             .version("0.1")
             .author("gcarq <egger.m@protonmail.com>")

--- a/src/callbacks/unspentcsvdump.rs
+++ b/src/callbacks/unspentcsvdump.rs
@@ -5,7 +5,7 @@ use std::io::{BufWriter, Write};
 use std::path::PathBuf;
 
 use byteorder::{LittleEndian, ReadBytesExt};
-use clap::{App, Arg, ArgMatches, SubCommand};
+use clap::{Arg, ArgMatches, Command};
 
 use crate::blockchain::proto::block::Block;
 use crate::callbacks::{common, Callback};
@@ -32,16 +32,16 @@ impl UnspentCsvDump {
 }
 
 impl Callback for UnspentCsvDump {
-    fn build_subcommand<'a, 'b>() -> App<'a, 'b>
+    fn build_subcommand() -> Command
     where
         Self: Sized,
     {
-        SubCommand::with_name("unspentcsvdump")
+        Command::new("unspentcsvdump")
             .about("Dumps the unspent outputs to CSV file")
             .version("0.1")
             .author("fsvm88 <fsvm88@gmail.com>")
             .arg(
-                Arg::with_name("dump-folder")
+                Arg::new("dump-folder")
                     .help("Folder to store csv file")
                     .index(1)
                     .required(true),
@@ -52,7 +52,7 @@ impl Callback for UnspentCsvDump {
     where
         Self: Sized,
     {
-        let dump_folder = &PathBuf::from(matches.value_of("dump-folder").unwrap());
+        let dump_folder = &PathBuf::from(matches.get_one::<String>("dump-folder").unwrap());
         let cb = UnspentCsvDump {
             dump_folder: PathBuf::from(dump_folder),
             writer: UnspentCsvDump::create_writer(4000000, dump_folder.join("unspent.csv.tmp"))?,


### PR DESCRIPTION
This gets rid of two security advisories [1, 2]
reported by `cargo audit` [3]. After this commit,
no other vulnerabilities are reported by the tool.

This is a heavily breaking change, as the `Callback` trait had to be adapted.

We prefer to keep the diff as minimal as possible, rather than strive for the maximally idiomatic code. Thus, we refrain for now from optimizations such as deriving `clap::ValueEnum` on
`blockchain::parser::types::CoinType`, or using
`clap::command!()` to read the crate author and
version from the Cargo manifest.

We reshuffle the argument parsing code a bit in
order to be able to add a set of unit tests that
assert some basic desired behaviors.

The updated help text is reflected in the diff of
the README file.

[1] https://rustsec.org/advisories/RUSTSEC-2021-0139

[2] https://rustsec.org/advisories/RUSTSEC-2021-0145

[3] https://crates.io/crates/cargo-audit

Closes #95.